### PR TITLE
Support calling stencils with lower dimensional fields

### DIFF
--- a/src/gt4py/backend/debug_backend.py
+++ b/src/gt4py/backend/debug_backend.py
@@ -112,7 +112,7 @@ class DebugSourceGenerator(PythonSourceGenerator):
     def visit_FieldRef(self, node: gt_ir.FieldRef):
         assert node.name in self.block_info.accessors
         index = []
-        for ax in self.domain.axes_names:
+        for ax in self.impl_node.fields[node.name].axes:
             offset = "{:+d}".format(node.offset[ax]) if ax in node.offset else ""
             index.append("{ax}{offset}".format(ax=ax, offset=offset))
 
@@ -184,6 +184,7 @@ class _Accessor:
         self.origin = origin
 
     def _shift(self, index):
+        index = index if isinstance(index, Iterable) else (index,)
         return tuple(i + offset for i, offset in zip(index, self.origin))
 
     def __getitem__(self, index):
@@ -204,6 +205,7 @@ class _Accessor:
         source = (
             """
 import math
+from collections.abc import Iterable
 """
             + super().generate_imports()
         )

--- a/src/gt4py/backend/debug_backend.py
+++ b/src/gt4py/backend/debug_backend.py
@@ -116,8 +116,9 @@ class DebugSourceGenerator(PythonSourceGenerator):
             offset = "{:+d}".format(node.offset[ax]) if ax in node.offset else ""
             index.append("{ax}{offset}".format(ax=ax, offset=offset))
 
+        index_str = f"({index[0]},)" if len(index) == 1 else ", ".join(index)
         source = "{name}{marker}[{index}]".format(
-            marker=self.origin_marker, name=node.name, index=", ".join(index)
+            marker=self.origin_marker, name=node.name, index=index_str
         )
 
         return source
@@ -184,7 +185,6 @@ class _Accessor:
         self.origin = origin
 
     def _shift(self, index):
-        index = index if isinstance(index, Iterable) else (index,)
         return tuple(i + offset for i, offset in zip(index, self.origin))
 
     def __getitem__(self, index):
@@ -205,7 +205,6 @@ class _Accessor:
         source = (
             """
 import math
-from collections.abc import Iterable
 """
             + super().generate_imports()
         )

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -410,7 +410,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
         # Initialize symbols for the generation of references in this stage
         self.stage_symbols = {}
         args = []
-        axis_to_index = {"I": 0, "J": 1, "K": 2}
+
         for accessor in node.accessors:
             self.stage_symbols[accessor.symbol] = accessor
             arg = {"name": accessor.symbol, "access_type": "in", "extent": None}
@@ -419,10 +419,9 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
                     "in" if accessor.intent == gt_ir.AccessIntent.READ_ONLY else "inout"
                 )
                 arg["extent"] = gt_utils.flatten(
-                    [
-                        accessor.extent[axis_to_index[axis]]
-                        for axis in self.impl_node.fields[accessor.symbol].axes
-                    ]
+                    gt_utils.filter_from_axes(
+                        accessor.extent, self.impl_node.fields[accessor.symbol].axes
+                    )
                 )
             args.append(arg)
 

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -54,9 +54,10 @@ def make_x86_layout_map(mask: Tuple[int, ...]) -> Tuple[Optional[int], ...]:
 def x86_is_compatible_layout(field: "Storage") -> bool:
     stride = 0
     layout_map = make_x86_layout_map(field.mask)
-    if len(field.strides) < len(layout_map):
+    flattened_layout = [index for index in layout_map if index is not None]
+    if len(field.strides) < len(flattened_layout):
         return False
-    for dim in reversed(np.argsort(layout_map)):
+    for dim in reversed(np.argsort(flattened_layout)):
         if field.strides[dim] < stride:
             return False
         stride = field.strides[dim]
@@ -459,6 +460,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
                 field_attributes = {
                     "name": field_decl.name,
                     "dtype": self._make_cpp_type(field_decl.data_type),
+                    "axes": field_decl.axes,
                 }
                 if field_decl.is_api:
                     if field_decl.layout_id not in storage_ids:

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -410,7 +410,6 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
         # Initialize symbols for the generation of references in this stage
         self.stage_symbols = {}
         args = []
-
         for accessor in node.accessors:
             self.stage_symbols[accessor.symbol] = accessor
             arg = {"name": accessor.symbol, "access_type": "in", "extent": None}

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -90,9 +90,10 @@ def make_mc_layout_map(mask: Tuple[int, ...]) -> Tuple[Optional[int], ...]:
 def mc_is_compatible_layout(field: "Storage") -> bool:
     stride = 0
     layout_map = make_mc_layout_map(field.mask)
-    if len(field.strides) < len(layout_map):
+    flattened_layout = [index for index in layout_map if index is not None]
+    if len(field.strides) < len(flattened_layout):
         return False
-    for dim in reversed(np.argsort(layout_map)):
+    for dim in reversed(np.argsort(flattened_layout)):
         if field.strides[dim] < stride:
             return False
         stride = field.strides[dim]

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -33,6 +33,8 @@
 
 namespace py = ::pybind11;
 
+static constexpr int MAX_DIM = 3;
+
 namespace {
 
 BufferInfo make_buffer_info(py::object& b) {
@@ -43,7 +45,7 @@ BufferInfo make_buffer_info(py::object& b) {
 //    auto strides_tuple = b.attr("strides").cast<std::tuple<int, int, int>>();
 //    std::vector<py_size_t> strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple), std::get<2>(strides_tuple)};
 //    void* ptr =  reinterpret_cast<void*>(b.attr("data").attr("ptr").cast<std::size_t>());
-    py_size_t ndim = 3;
+    py_size_t ndim = MAX_DIM;
     py::dict __cuda_array_interface__ = b.attr("__cuda_array_interface__").cast<py::dict>();
     auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int, int, int>>();
     std::vector<py_size_t> shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple), std::get<2>(shape_tuple)};
@@ -62,7 +64,7 @@ BufferInfo make_buffer_info(py::object& b) {
     return BufferInfo{ndim, shape, strides, ptr};
 }
 
-void run_computation(const std::array<gt::uint_t, 3>& domain,
+void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
 {%- set comma = joiner(", ") -%}
 {%- for field in arg_fields -%}
                      {{- comma() }}

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -59,13 +59,6 @@ BufferInfo make_buffer_info(py::object& b) {
     void* ptr = static_cast<void*>(buffer_info.ptr);
 {%- endif %}
 
-    // TODO Is this accurate?
-    // if (ndim != 3) {
-    //     throw std::runtime_error("Wrong number of dimensions [" +
-    //                              std::to_string(ndim) +
-    //                              " != " + std::to_string(3) + "]");
-    // }
-
     return BufferInfo{ndim, shape, strides, ptr};
 }
 

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -16,7 +16,7 @@
 
  ---- Template variables ----
 
-    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int }]
+    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int, "axes": [str] }]
     - gt_backend: str
     - module_name: str
     - parameters: [{ "name": str, "dtype": str }]
@@ -59,11 +59,12 @@ BufferInfo make_buffer_info(py::object& b) {
     void* ptr = static_cast<void*>(buffer_info.ptr);
 {%- endif %}
 
-    if (ndim != 3) {
-        throw std::runtime_error("Wrong number of dimensions [" +
-                                 std::to_string(ndim) +
-                                 " != " + std::to_string(3) + "]");
-    }
+    // TODO Is this accurate?
+    // if (ndim != 3) {
+    //     throw std::runtime_error("Wrong number of dimensions [" +
+    //                              std::to_string(ndim) +
+    //                              " != " + std::to_string(3) + "]");
+    // }
 
     return BufferInfo{ndim, shape, strides, ptr};
 }
@@ -72,7 +73,7 @@ void run_computation(const std::array<gt::uint_t, 3>& domain,
 {%- set comma = joiner(", ") -%}
 {%- for field in arg_fields -%}
                      {{- comma() }}
-                     py::object {{ field.name }}, const std::array<gt::uint_t, 3>& {{ field.name }}_origin
+                     py::object {{ field.name }}, const std::array<gt::uint_t, {{ field.axes | length }}>& {{ field.name }}_origin
 {%- endfor -%}
 {%- for param in parameters -%}
                      {{- comma() }}

--- a/src/gt4py/backend/templates/computation.hpp.in
+++ b/src/gt4py/backend/templates/computation.hpp.in
@@ -16,7 +16,7 @@
 
  ---- Template variables ----
 
-    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int }]
+    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int, "axes": [str] }]
     - parameters: [{ "name": str, "dtype": str }]
     - stencil_unique_name: str
 #}
@@ -53,7 +53,7 @@ void run(const std::array<gt::uint_t, 3>& domain,
 {%- set comma = joiner(", ") %}
 {%- for field in arg_fields -%}
          {{- comma() }}
-         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, 3>& {{ field.name }}_origin
+         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, {{ field.axes | length }}>& {{ field.name }}_origin
 {%- endfor %}
 {%- for param in parameters %}
          {{- comma() }}

--- a/src/gt4py/backend/templates/computation.src.in
+++ b/src/gt4py/backend/templates/computation.src.in
@@ -61,6 +61,8 @@
 #include <cmath>
 {%- endif %}
 
+static constexpr int MAX_DIM = 3;
+
 namespace {{ stencil_unique_name }} {
 
 namespace {
@@ -84,7 +86,7 @@ static constexpr gt::uint_t halo_size_k = {{ halo_sizes[2] }};
 template <int Id>
 using storage_info_t =
     gt::storage_traits<backend_t>::storage_info_t<
-        Id, 3,
+        Id, MAX_DIM,
         gt::halo<0, 0, 0 /* not used */>>;
 
 template<typename T, int Id>
@@ -153,7 +155,7 @@ gt::halo_descriptor make_halo_descriptor(gt::uint_t compute_domain_shape) {
             compute_domain_shape};
 }
 
-auto make_grid(const std::array<gt::uint_t, 3>& compute_domain_shape) {
+auto make_grid(const std::array<gt::uint_t, MAX_DIM>& compute_domain_shape) {
     return gt::make_grid(make_halo_descriptor(compute_domain_shape[0]),
                          make_halo_descriptor(compute_domain_shape[1]),
                          axis_t(compute_domain_shape[2]));
@@ -162,20 +164,20 @@ auto make_grid(const std::array<gt::uint_t, 3>& compute_domain_shape) {
 
 template<typename T, int Id, int N>
 data_store_t<T, Id> make_data_store(const BufferInfo& bi,
-                                    const std::array<gt::uint_t, 3>& compute_domain_shape,
+                                    const std::array<gt::uint_t, MAX_DIM>& compute_domain_shape,
                                     const std::array<gt::uint_t, N>& origin,
                                     const char* axes)
 {
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and
     // currently, in the storage info)
-    gt::array<gt::uint_t, 3> dims{};
-    gt::array<gt::uint_t, 3> strides{};
+    gt::array<gt::uint_t, MAX_DIM> dims{};
+    gt::array<gt::uint_t, MAX_DIM> strides{};
     T* ptr = static_cast<T*>(bi.ptr);
 
-    const std::array<char, 3> all_axes = {'I', 'J', 'K'};
+    const std::array<char, MAX_DIM> all_axes = {'I', 'J', 'K'};
     gt::uint_t curr_stride = 0, curr_origin = 0;
-    for (int i = 0, j = 0; i < 3; ++i) {
+    for (int i = 0, j = 0; i < MAX_DIM; ++i) {
         if (j < N && axes[j] == all_axes[i]) {
             curr_stride = bi.strides[j];
             curr_origin = origin[j];
@@ -207,7 +209,7 @@ gt::global_parameter<{{ param.dtype }}> {{ param.name }}_param = gt::make_global
 
 
 // Run actual computation
-void run(const std::array<gt::uint_t, 3>& domain,
+void run(const std::array<gt::uint_t, MAX_DIM>& domain,
 {%- set comma = joiner(", ") %}
 {%- for field in arg_fields -%}
          {{- comma() }}

--- a/src/gt4py/backend/templates/computation.src.in
+++ b/src/gt4py/backend/templates/computation.src.in
@@ -166,12 +166,6 @@ data_store_t<T, Id> make_data_store(const BufferInfo& bi,
                                     const std::array<gt::uint_t, N>& origin,
                                     const char* axes)
 {
-    // if (bi.ndim != 3) {
-    //    throw std::runtime_error("Wrong number of dimensions [" +
-    //                              std::to_string(bi.ndim) +
-    //                              " != " + std::to_string(3) + "]");
-    // }
-
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and
     // currently, in the storage info)

--- a/src/gt4py/backend/templates/computation.src.in
+++ b/src/gt4py/backend/templates/computation.src.in
@@ -16,7 +16,7 @@
 
  ---- Template variables ----
 
-    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int }]
+    - arg_fields: [{ "name": str, "dtype": str, "layout_id": int, "axes": [str] }]
     - constants: { name:str : str }
     - gt_backend: str
     - halo_sizes: [int]
@@ -160,16 +160,17 @@ auto make_grid(const std::array<gt::uint_t, 3>& compute_domain_shape) {
 }
 
 
-template<typename T, int Id>
+template<typename T, int Id, int N>
 data_store_t<T, Id> make_data_store(const BufferInfo& bi,
                                     const std::array<gt::uint_t, 3>& compute_domain_shape,
-                                    const std::array<gt::uint_t, 3>& origin)
+                                    const std::array<gt::uint_t, N>& origin,
+                                    const char* axes)
 {
-    if (bi.ndim != 3) {
-        throw std::runtime_error("Wrong number of dimensions [" +
-                                 std::to_string(bi.ndim) +
-                                 " != " + std::to_string(3) + "]");
-    }
+    // if (bi.ndim != 3) {
+    //    throw std::runtime_error("Wrong number of dimensions [" +
+    //                              std::to_string(bi.ndim) +
+    //                              " != " + std::to_string(3) + "]");
+    // }
 
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and
@@ -177,10 +178,20 @@ data_store_t<T, Id> make_data_store(const BufferInfo& bi,
     gt::array<gt::uint_t, 3> dims{};
     gt::array<gt::uint_t, 3> strides{};
     T* ptr = static_cast<T*>(bi.ptr);
-    for (int i = 0; i < 3; ++i) {
-        strides[i] = bi.strides[i] / sizeof(T);
-        ptr += strides[i] * origin[i];
-        dims[i] = compute_domain_shape[i]+2*origin[i];
+
+    const std::array<char, 3> all_axes = {'I', 'J', 'K'};
+    gt::uint_t curr_stride = 0, curr_origin = 0;
+    for (int i = 0, j = 0; i < 3; ++i) {
+        if (j < N && axes[j] == all_axes[i]) {
+            curr_stride = bi.strides[j];
+            curr_origin = origin[j];
+            ++j;
+        } else {
+            curr_origin = 0;
+        }
+        strides[i] = curr_stride / sizeof(T);
+        dims[i] = compute_domain_shape[i] + 2 * curr_origin;
+        ptr += strides[i] * curr_origin;
     }
     return data_store_t<T, Id>{storage_info_t<Id>{dims, strides}, ptr,
 {%- if gt_backend == "cuda" %}
@@ -206,7 +217,7 @@ void run(const std::array<gt::uint_t, 3>& domain,
 {%- set comma = joiner(", ") %}
 {%- for field in arg_fields -%}
          {{- comma() }}
-         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, 3>& {{ field.name }}_origin
+         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, {{ field.axes | length }}>& {{ field.name }}_origin
 {%- endfor %}
 {%- for param in parameters %}
          {{- comma() }}
@@ -232,7 +243,7 @@ void run(const std::array<gt::uint_t, 3>& domain,
 #}
     // Initialize data stores from input buffers
 {%- for field in arg_fields %}
-    auto ds_{{ field.name }} = make_data_store<{{ field.dtype }}, {{ field.layout_id }}>(bi_{{ field.name }}, domain, {{ field.name }}_origin);
+    auto ds_{{ field.name }} = make_data_store<{{ field.dtype }}, {{ field.layout_id }}, {{ field.axes | length }}>(bi_{{ field.name }}, domain, {{ field.name }}_origin, "{{ "".join(field.axes) }}");
 {%- endfor %}
 
     // Update global parameters

--- a/src/gt4py/backend/templates/dawn_computation.src.in
+++ b/src/gt4py/backend/templates/dawn_computation.src.in
@@ -45,17 +45,17 @@ using backend_t = DAWN_GT_BACKEND;
 #include <cassert>
 #include <stdexcept>
 
-static constexpr int NDIM = 3;
+static constexpr int MAX_DIM = 3;
 
 namespace {{ stencil_unique_name }} {
 
 namespace {
 
-std::array<gt::uint_t, NDIM> get_min_origin(
-    const std::initializer_list<const std::array<gt::uint_t, NDIM>>& origins) {
-    std::array<gt::uint_t, NDIM> min_origin = *origins.begin();
+std::array<gt::uint_t, MAX_DIM> get_min_origin(
+    const std::initializer_list<const std::array<gt::uint_t, MAX_DIM>>& origins) {
+    std::array<gt::uint_t, MAX_DIM> min_origin = *origins.begin();
     for(const auto& origin : origins) {
-        for(int i = 0; i < NDIM; ++i) {
+        for(int i = 0; i < MAX_DIM; ++i) {
             if(origin[i] < min_origin[i])
                 min_origin[i] = origin[i];
         }
@@ -63,10 +63,10 @@ std::array<gt::uint_t, NDIM> get_min_origin(
     return min_origin;
 }
 
-gridtools::dawn::domain make_domain(const std::array<gt::uint_t, NDIM> &in_size,
-                                    const std::array<gt::uint_t, NDIM> &min_origin) {
-    std::array<gt::uint_t, NDIM> size;
-    for (int i = 0; i < NDIM; ++i) {
+gridtools::dawn::domain make_domain(const std::array<gt::uint_t, MAX_DIM> &in_size,
+                                    const std::array<gt::uint_t, MAX_DIM> &min_origin) {
+    std::array<gt::uint_t, MAX_DIM> size;
+    for (int i = 0; i < MAX_DIM; ++i) {
       size[i] = in_size[i] + 2 * min_origin[i];
     }
 
@@ -84,18 +84,18 @@ static_assert(
 // Constants
 template<typename T>
 data_store_t make_data_store(const BufferInfo& bi,
-                             const std::array<gt::uint_t, NDIM>& compute_domain_shape,
-                             const std::array<gt::uint_t, NDIM>& origin)
+                             const std::array<gt::uint_t, MAX_DIM>& compute_domain_shape,
+                             const std::array<gt::uint_t, MAX_DIM>& origin)
 {
     static_assert(std::is_same<T, double>::value, "Only double is supported right now");
 
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and
     // currently, in the storage info)
-    gt::array<gt::uint_t, NDIM> dims{};
-    gt::array<gt::uint_t, NDIM> strides{};
+    gt::array<gt::uint_t, MAX_DIM> dims{};
+    gt::array<gt::uint_t, MAX_DIM> strides{};
     double* ptr = static_cast<double*>(bi.ptr);
-    for (int i = 0; i < NDIM; ++i) {
+    for (int i = 0; i < MAX_DIM; ++i) {
         strides[i] = bi.strides[i] / sizeof(double);
         dims[i] = compute_domain_shape[i]+2*origin[i];
     }
@@ -111,11 +111,11 @@ data_store_t make_data_store(const BufferInfo& bi,
 
 
 // Run actual computation
-void run(const std::array<gt::uint_t, NDIM>& domain,
+void run(const std::array<gt::uint_t, MAX_DIM>& domain,
 {%- set comma = joiner(", ") %}
 {%- for field in arg_fields -%}
          {{- comma() }}
-         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, NDIM>& {{ field.name }}_origin
+         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, MAX_DIM>& {{ field.name }}_origin
 {%- endfor %}
 {%- for param in parameters %}
          {{- comma() }}
@@ -123,7 +123,7 @@ void run(const std::array<gt::uint_t, NDIM>& domain,
 {%- endfor %})
 {
     // Compute min origin
-    std::array<gt::uint_t, NDIM> min_origin = get_min_origin({
+    std::array<gt::uint_t, MAX_DIM> min_origin = get_min_origin({
 {%- for field in arg_fields -%}
          {{ field.name }}_origin {{ comma() if not loop.last }}
 {%- endfor -%}

--- a/src/gt4py/backend/templates/dawn_computation.src.in
+++ b/src/gt4py/backend/templates/dawn_computation.src.in
@@ -86,11 +86,6 @@ data_store_t make_data_store(const BufferInfo& bi,
                              const std::array<gt::uint_t, 3>& origin)
 {
     static_assert(std::is_same<T, double>::value, "Only double is supported right now");
-    if (bi.ndim != 3) {
-        throw std::runtime_error("Wrong number of dimensions [" +
-                                 std::to_string(bi.ndim) +
-                                 " != " + std::to_string(3) + "]");
-    }
 
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and

--- a/src/gt4py/backend/templates/dawn_computation.src.in
+++ b/src/gt4py/backend/templates/dawn_computation.src.in
@@ -45,15 +45,17 @@ using backend_t = DAWN_GT_BACKEND;
 #include <cassert>
 #include <stdexcept>
 
+static constexpr int NDIM = 3;
+
 namespace {{ stencil_unique_name }} {
 
 namespace {
 
-std::array<gt::uint_t, 3> get_min_origin(
-    const std::initializer_list<const std::array<gt::uint_t, 3>>& origins) {
-    std::array<gt::uint_t, 3> min_origin = *origins.begin();
+std::array<gt::uint_t, NDIM> get_min_origin(
+    const std::initializer_list<const std::array<gt::uint_t, NDIM>>& origins) {
+    std::array<gt::uint_t, NDIM> min_origin = *origins.begin();
     for(const auto& origin : origins) {
-        for(int i = 0; i < 3; ++i) {
+        for(int i = 0; i < NDIM; ++i) {
             if(origin[i] < min_origin[i])
                 min_origin[i] = origin[i];
         }
@@ -61,10 +63,10 @@ std::array<gt::uint_t, 3> get_min_origin(
     return min_origin;
 }
 
-gridtools::dawn::domain make_domain(const std::array<gt::uint_t, 3> &in_size,
-                                    const std::array<gt::uint_t, 3> &min_origin) {
-    std::array<gt::uint_t, 3> size;
-    for (int i = 0; i < 3; ++i) {
+gridtools::dawn::domain make_domain(const std::array<gt::uint_t, NDIM> &in_size,
+                                    const std::array<gt::uint_t, NDIM> &min_origin) {
+    std::array<gt::uint_t, NDIM> size;
+    for (int i = 0; i < NDIM; ++i) {
       size[i] = in_size[i] + 2 * min_origin[i];
     }
 
@@ -82,18 +84,18 @@ static_assert(
 // Constants
 template<typename T>
 data_store_t make_data_store(const BufferInfo& bi,
-                             const std::array<gt::uint_t, 3>& compute_domain_shape,
-                             const std::array<gt::uint_t, 3>& origin)
+                             const std::array<gt::uint_t, NDIM>& compute_domain_shape,
+                             const std::array<gt::uint_t, NDIM>& origin)
 {
     static_assert(std::is_same<T, double>::value, "Only double is supported right now");
 
     // ptr, dims and strides are "outer domain" (i.e., compute domain + halo
     // region). The halo region is only defined through `make_grid` (and
     // currently, in the storage info)
-    gt::array<gt::uint_t, 3> dims{};
-    gt::array<gt::uint_t, 3> strides{};
+    gt::array<gt::uint_t, NDIM> dims{};
+    gt::array<gt::uint_t, NDIM> strides{};
     double* ptr = static_cast<double*>(bi.ptr);
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < NDIM; ++i) {
         strides[i] = bi.strides[i] / sizeof(double);
         dims[i] = compute_domain_shape[i]+2*origin[i];
     }
@@ -109,11 +111,11 @@ data_store_t make_data_store(const BufferInfo& bi,
 
 
 // Run actual computation
-void run(const std::array<gt::uint_t, 3>& domain,
+void run(const std::array<gt::uint_t, NDIM>& domain,
 {%- set comma = joiner(", ") %}
 {%- for field in arg_fields -%}
          {{- comma() }}
-         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, 3>& {{ field.name }}_origin
+         const BufferInfo& bi_{{ field.name }} {{- comma() -}} const std::array<gt::uint_t, NDIM>& {{ field.name }}_origin
 {%- endfor %}
 {%- for param in parameters %}
          {{- comma() }}
@@ -121,7 +123,7 @@ void run(const std::array<gt::uint_t, 3>& domain,
 {%- endfor %})
 {
     // Compute min origin
-    std::array<gt::uint_t, 3> min_origin = get_min_origin({
+    std::array<gt::uint_t, NDIM> min_origin = get_min_origin({
 {%- for field in arg_fields -%}
          {{ field.name }}_origin {{ comma() if not loop.last }}
 {%- endfor -%}

--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -85,7 +85,7 @@ class NumericTuple(tuple):
     def from_mask(cls, seq, mask, default=None):
         if default is None:
             default = cls._DEFAULT
-        return cls(gt_utils.filter_mask(seq, mask, default=default))
+        return cls(gt_utils.filter_mask_expand(seq, mask, default=default))
 
     @classmethod
     def from_value(cls, value):
@@ -222,6 +222,9 @@ class NumericTuple(tuple):
             raise ValueError("Incompatible instance '{obj}'".format(obj=other))
 
         return all(op(a, b) for a, b in zip(self, other))
+
+    def filter_mask(self, mask):
+        return type(self)(gt_utils.filter_mask_shrink(self, mask))
 
 
 class Index(NumericTuple):

--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -47,6 +47,8 @@ class NumericTuple(tuple):
 
     __slots__ = ()
 
+    _DEFAULT = 0
+
     @classmethod
     def _check_value(cls, value, ndims):
         assert isinstance(value, collections.abc.Sequence), "Invalid sequence"
@@ -78,6 +80,12 @@ class NumericTuple(tuple):
     @classmethod
     def from_k(cls, value, ndims=CartesianSpace.ndims):
         return cls([value] * ndims, ndims=(ndims, ndims))
+
+    @classmethod
+    def from_mask(cls, seq, mask, default=None):
+        if default is None:
+            default = cls._DEFAULT
+        return cls(gt_utils.filter_mask(seq, mask, default=default))
 
     @classmethod
     def from_value(cls, value):
@@ -232,6 +240,8 @@ class Shape(NumericTuple):
     """Shape of a n-dimensional grid (all elements are int >= 0)."""
 
     __slots__ = ()
+
+    _DEFAULT = 1
 
     @classmethod
     def _check_value(cls, value, ndims):

--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -85,7 +85,7 @@ class NumericTuple(tuple):
     def from_mask(cls, seq, mask, default=None):
         if default is None:
             default = cls._DEFAULT
-        return cls(gt_utils.filter_mask_expand(seq, mask, default=default))
+        return cls(gt_utils.interpolate_mask(seq, mask, default))
 
     @classmethod
     def from_value(cls, value):
@@ -224,7 +224,7 @@ class NumericTuple(tuple):
         return all(op(a, b) for a, b in zip(self, other))
 
     def filter_mask(self, mask):
-        return type(self)(gt_utils.filter_mask_shrink(self, mask))
+        return type(self)(gt_utils.filter_mask(self, mask))
 
 
 class Index(NumericTuple):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1466,7 +1466,9 @@ class GTScriptParser(ast.NodeVisitor):
 
         # Resolve function-like imports
         func_externals = {
-            key: value for key, value in context.items() if isinstance(value, types.FunctionType)
+            key: value
+            for key, value in itertools.chain(context.items(), resolved_values_list)
+            if isinstance(value, types.FunctionType)
         }
         for name, value in func_externals.items():
             if isinstance(value, types.FunctionType) and not hasattr(value, "_gtscript_"):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -361,38 +361,34 @@ class ValueInliner(ast.NodeTransformer):
         return node
 
 
-class ReturnReplacer(ast.NodeTransformer):
+class ReturnReplacer(gt_utils.meta.ASTTransformPass):
     @classmethod
-    def apply(cls, ast_object, target_node):
-        replacer = cls(target_node)
-        replacer(ast_object)
+    def apply(cls, ast_object: ast.AST, target_node: ast.AST) -> None:
+        """Ensure that there is only a single return statement (can still return a tuple)."""
+        ret_count = sum(isinstance(node, ast.Return) for node in ast.walk(ast_object))
+        if ret_count != 1:
+            raise GTScriptSyntaxError("GTScript Functions should have a single return statement")
+        cls().visit(ast_object, target_node=target_node)
 
-    def __init__(self, target_node):
-        self.target_node = target_node
+    @staticmethod
+    def _get_num_values(node: ast.AST) -> int:
+        return len(node.elts) if isinstance(node, ast.Tuple) else 1
 
-    def __call__(self, ast_object):
-        self.visit(ast_object)
-
-    def visit_Return(self, node: ast.Return):
-        if isinstance(node.value, ast.Tuple):
-            rhs_length = len(node.value.elts)
-        else:
-            rhs_length = 1
-
-        if isinstance(self.target_node, ast.Tuple):
-            lhs_length = len(self.target_node.elts)
-        else:
-            lhs_length = 1
+    def visit_Return(self, node: ast.Return, *, target_node: ast.AST) -> ast.Assign:
+        rhs_length = self._get_num_values(node.value)
+        lhs_length = self._get_num_values(target_node)
 
         if lhs_length == rhs_length:
             return ast.Assign(
-                targets=[self.target_node],
+                targets=[target_node],
                 value=node.value,
                 lineno=node.lineno,
                 col_offset=node.col_offset,
             )
         else:
-            return ast.Raise(lineno=node.lineno, col_offset=node.col_offset)
+            raise GTScriptSyntaxError(
+                "Number of returns values does not match arguments on left side"
+            )
 
 
 class CallInliner(ast.NodeTransformer):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -961,7 +961,9 @@ class IRMaker(ast.NodeVisitor):
         if isinstance(result, gt_ir.VarRef):
             result.index = index
         else:
-            result.offset = {axis.name: value for axis, value in zip(self.domain.axes, index)}
+            result.offset = {
+                axis.name: value for axis, value in zip(self.domain.axes, gt_utils.listify(index))
+            }
 
         return result
 

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -961,8 +961,9 @@ class IRMaker(ast.NodeVisitor):
         if isinstance(result, gt_ir.VarRef):
             result.index = index
         else:
+            field_axes = self.fields[result.name].axes
             result.offset = {
-                axis.name: value for axis, value in zip(self.domain.axes, gt_utils.listify(index))
+                axis: value for axis, value in zip(field_axes, gt_utils.listify(index))
             }
 
         return result

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -29,9 +29,12 @@ import os
 import string
 import sys
 import types
+from typing import Any, Sequence, Tuple, TypeVar
 
 
 NOTHING = object()
+
+T = TypeVar("T")
 
 
 def slugify(value: str, *, replace_spaces=True, valid_symbols="-_.()", invalid_marker=""):
@@ -201,6 +204,22 @@ def shash(*args, hash_algorithm=None):
 
 def shashed_id(*args, length=10, hash_algorithm=None):
     return shash(*args, hash_algorithm=hash_algorithm)[:length]
+
+
+def filter_mask(seq: Sequence[Any], mask: Sequence[bool], *, default) -> Tuple[Any, ...]:
+    """
+    Return a tuple with the same shape as mask, with True values replaced by
+    the sequence, and False values replaced by default.
+
+    Example:
+    >>> default = 0
+    >>> a = (1, 2)
+    >>> mask = (False, True, False, True)
+    >>> filter_mask(a, mask, default=1)
+    (0, 1, 0, 2)
+    """
+    it = iter(seq)
+    return tuple(it.__next__() if m else default for m in mask)
 
 
 def classmethod_to_function(class_method, instance=None, owner=type(None), remove_cls_arg=False):

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -204,7 +204,7 @@ def shashed_id(*args, length=10, hash_algorithm=None):
     return shash(*args, hash_algorithm=hash_algorithm)[:length]
 
 
-def filter_mask(seq: Sequence[Any], mask: Sequence[bool], *, default) -> Tuple[Any, ...]:
+def filter_mask_expand(seq: Sequence[Any], mask: Sequence[bool], *, default) -> Tuple[Any, ...]:
     """
     Return a tuple with the same shape as mask, with True values replaced by
     the sequence, and False values replaced by default.
@@ -213,11 +213,25 @@ def filter_mask(seq: Sequence[Any], mask: Sequence[bool], *, default) -> Tuple[A
     >>> default = 0
     >>> a = (1, 2)
     >>> mask = (False, True, False, True)
-    >>> filter_mask(a, mask, default=1)
+    >>> filter_mask_expand(a, mask, default=1)
     (0, 1, 0, 2)
     """
     it = iter(seq)
     return tuple(it.__next__() if m else default for m in mask)
+
+
+def filter_mask_shrink(seq: Sequence[Any], mask: Sequence[bool]) -> Tuple[Any, ...]:
+    """
+    Return a tuple with the same shape as mask, with True values replaced by
+    the sequence, and False values replaced by default.
+
+    Example:
+    >>> a = (1, 2, 3)
+    >>> mask = (False, True, False)
+    >>> filter_mask_shrink(a, mask)
+    (2,)
+    """
+    return tuple(s for m, s in zip(mask, seq) if m)
 
 
 def classmethod_to_function(class_method, instance=None, owner=type(None), remove_cls_arg=False):

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -222,8 +222,7 @@ def filter_mask_expand(seq: Sequence[Any], mask: Sequence[bool], *, default) -> 
 
 def filter_mask_shrink(seq: Sequence[Any], mask: Sequence[bool]) -> Tuple[Any, ...]:
     """
-    Return a tuple with the same shape as mask, with True values replaced by
-    the sequence, and False values replaced by default.
+    Return a reduced-size tuple, with indices where mask[i]=False removed.
 
     Example:
     >>> a = (1, 2, 3)

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -29,12 +29,10 @@ import os
 import string
 import sys
 import types
-from typing import Any, Sequence, Tuple, TypeVar
+from typing import Any, Sequence, Tuple
 
 
 NOTHING = object()
-
-T = TypeVar("T")
 
 
 def slugify(value: str, *, replace_spaces=True, valid_symbols="-_.()", invalid_marker=""):

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -233,6 +233,21 @@ def filter_mask(seq: Sequence[Any], mask: Sequence[bool]) -> Tuple[Any, ...]:
     return tuple(s for m, s in zip(mask, seq) if m)
 
 
+def filter_from_axes(seq: Sequence[Any], axes: Sequence[str]) -> Tuple[Any, ...]:
+    """
+    Return a sequence that is filtered on the axes provided.
+
+    Example:
+    >>> a = (1, 2, 3)
+    >>> axes = ("J",)
+    >>> filter_from_axes(a, axes)
+    (2,)
+    """
+    axis_to_index = {"I": 0, "J": 1, "K": 2}
+    assert all(axis in axis_to_index for axis in axes), f"Unknown axis in: {axes}"
+    return tuple(seq[axis_to_index[axis]] for axis in axes)
+
+
 def classmethod_to_function(class_method, instance=None, owner=type(None), remove_cls_arg=False):
     if remove_cls_arg:
         return functools.partial(class_method.__get__(instance, owner), None)

--- a/src/gt4py/utils/base.py
+++ b/src/gt4py/utils/base.py
@@ -204,7 +204,7 @@ def shashed_id(*args, length=10, hash_algorithm=None):
     return shash(*args, hash_algorithm=hash_algorithm)[:length]
 
 
-def filter_mask_expand(seq: Sequence[Any], mask: Sequence[bool], *, default) -> Tuple[Any, ...]:
+def interpolate_mask(seq: Sequence[Any], mask: Sequence[bool], default) -> Tuple[Any, ...]:
     """
     Return a tuple with the same shape as mask, with True values replaced by
     the sequence, and False values replaced by default.
@@ -213,21 +213,21 @@ def filter_mask_expand(seq: Sequence[Any], mask: Sequence[bool], *, default) -> 
     >>> default = 0
     >>> a = (1, 2)
     >>> mask = (False, True, False, True)
-    >>> filter_mask_expand(a, mask, default=1)
+    >>> interpolate_mask(a, mask, 1)
     (0, 1, 0, 2)
     """
     it = iter(seq)
     return tuple(it.__next__() if m else default for m in mask)
 
 
-def filter_mask_shrink(seq: Sequence[Any], mask: Sequence[bool]) -> Tuple[Any, ...]:
+def filter_mask(seq: Sequence[Any], mask: Sequence[bool]) -> Tuple[Any, ...]:
     """
     Return a reduced-size tuple, with indices where mask[i]=False removed.
 
     Example:
     >>> a = (1, 2, 3)
     >>> mask = (False, True, False)
-    >>> filter_mask_shrink(a, mask)
+    >>> filter_mask(a, mask)
     (2,)
     """
     return tuple(s for m, s in zip(mask, seq) if m)

--- a/src/gt4py/utils/meta.py
+++ b/src/gt4py/utils/meta.py
@@ -199,7 +199,9 @@ def get_qualified_name_from_node(name_or_attribute, *, as_list=False):
     return components if as_list else ".".join(components)
 
 
-class ASTPass(ast.NodeVisitor):
+class ASTPass:
+    """Clone of the ast.NodeVisitor that supports forwarding kwargs."""
+
     def __call__(self, func_or_source_or_ast):
         ast_root = get_ast(func_or_source_or_ast)
         return self.visit(ast_root)
@@ -222,6 +224,8 @@ class ASTPass(ast.NodeVisitor):
 
 
 class ASTTransformPass(ASTPass):
+    """Clone of the ast.NodeTransformer that supports forwarding kwargs."""
+
     def generic_visit(self, node, **kwargs):
         for field, old_value in ast.iter_fields(node):
             if isinstance(old_value, list):

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -30,16 +30,16 @@ REGISTRY = gt_utils.Registry()
 EXTERNALS_REGISTRY = gt_utils.Registry()
 
 
-def register(externals):
-    if callable(externals):
-        func = externals  # wacky hacky!
+def register(externals_or_func):
+    if callable(externals_or_func):
+        func = externals_or_func  # wacky hacky!
         EXTERNALS_REGISTRY.setdefault(func.__name__, {})
         REGISTRY.register(func.__name__, func)
         return func
     else:
 
         def register_inner(arg_inner):
-            EXTERNALS_REGISTRY.register(arg_inner.__name__, externals)
+            EXTERNALS_REGISTRY.register(arg_inner.__name__, externals_or_func)
             REGISTRY.register(arg_inner.__name__, arg_inner)
             return arg_inner
 
@@ -48,6 +48,7 @@ def register(externals):
 
 Field0D = gtscript.Field[np.float_, ()]
 Field3D = gtscript.Field[np.float_]
+Field3DBool = gtscript.Field[np.bool]
 
 
 @register
@@ -113,7 +114,7 @@ def tridiagonal_solver(inf: Field3D, diag: Field3D, sup: Field3D, rhs: Field3D, 
             out = rhs - sup * out[0, 0, 1]
 
 
-@register(externals={"BET_M": 0.5, "BET_P": 0.5})
+@register(externals_or_func={"BET_M": 0.5, "BET_P": 0.5})
 def vertical_advection_dycore(
     utens_stage: Field3D,
     u_stage: Field3D,
@@ -238,7 +239,7 @@ def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
 
 
 @register
-def set_inner_as_kord(a4_1: Field3D, a4_2: Field3D, a4_3: Field3D, extm: Field3D, qmin: float):
+def set_inner_as_kord(a4_1: Field3D, a4_2: Field3D, a4_3: Field3D, extm: Field3DBool):
     with computation(PARALLEL), interval(...):
         diff_23 = 0.0
         if extm and extm[0, 0, -1]:
@@ -263,9 +264,7 @@ def local_var_inside_nested_conditional(in_storage: Field3D, out_storage: Field3
 
 
 @register
-def multibranch_param_conditional(
-    in_field: gtscript.Field[float], out_field: gtscript.Field[float], c: float
-):
+def multibranch_param_conditional(in_field: Field3D, out_field: Field3D, c: float):
     with computation(PARALLEL), interval(...):
         if c > 0.0:
             out_field = in_field + in_field[1, 0, 0]
@@ -275,8 +274,8 @@ def multibranch_param_conditional(
             out_field = in_field
 
 
-@register(externals={"DO_SOMETHING": False})
-def allow_empty_computation(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+@register(externals_or_func={"DO_SOMETHING": False})
+def allow_empty_computation(in_field: Field3D, out_field: Field3D):
     from __externals__ import DO_SOMETHING
 
     with computation(FORWARD), interval(...):

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -211,4 +211,4 @@ def test_lower_dimensional_inputs(backend):
         backend, (default_origin[-1],), (full_shape[-1],), dtype, mask=(False, False, True)
     )
 
-    stencil(field_3d, field_2d, field_1d)
+    stencil(field_3d, field_2d, field_1d, origin=(1, 1, 0))

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -190,12 +190,12 @@ def test_lower_dimensional_inputs(backend):
         field_1d: gtscript.Field[np.float_, gtscript.K],
     ):
         with computation(PARALLEL), interval(0, 1):
-            field_2d = field_1d + field_3d
+            field_2d = field_1d[1] + field_3d[0, 1, 0]
 
         with computation(PARALLEL):
             with interval(0, 1):
-                tmp = field_2d + field_1d
-                field_3d = tmp[1, 0, 0] + field_1d
+                tmp = field_2d[0, 1] + field_1d[1]
+                field_3d = tmp[1, 0, 0] + field_1d[1]
             with interval(1, None):
                 field_3d = tmp[-1, 0, 0]
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -555,6 +555,91 @@ class TestExternalsWithSubroutines:
             )
 
 
+class TestFunctionReturn:
+    def test_no_return(self, id_version):
+        @gtscript.function
+        def _test_no_return(arg):
+            arg = 1
+
+        def definition_func(phi: gtscript.Field[np.float64]):
+            from __externals__ import test
+
+            with computation(PARALLEL), interval(...):
+                phi = test(phi)
+
+        module = f"TestFunctionReturn_test_no_return_{id_version}"
+        externals = {"test": _test_no_return}
+
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError, match="should have a single return statement"
+        ):
+            compile_definition(definition_func, "test_no_return", module, externals=externals)
+
+    def test_number_return_args(self, id_version):
+        @gtscript.function
+        def _test_return_args(arg):
+            return 1, 2
+
+        def definition_func(phi: gtscript.Field[np.float64]):
+            from __externals__ import test
+
+            with computation(PARALLEL), interval(...):
+                phi = test(phi)
+
+        module = f"TestFunctionReturn_test_number_return_args_{id_version}"
+        externals = {"test": _test_return_args}
+
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError,
+            match="Number of returns values does not match arguments on left side",
+        ):
+            compile_definition(
+                definition_func, "test_number_return_args", module, externals=externals
+            )
+
+    def test_multiple_return(self, id_version):
+        @gtscript.function
+        def _test_multiple_return(arg):
+            return 1
+            return 2
+
+        def definition_func(phi: gtscript.Field[np.float64]):
+            from __externals__ import test
+
+            with computation(PARALLEL), interval(...):
+                phi = test(phi)
+
+        module = f"TestFunctionReturn_test_multiple_return_{id_version}"
+        externals = {"test": _test_multiple_return}
+
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError, match="should have a single return statement"
+        ):
+            compile_definition(
+                definition_func, "test_multiple_return", module, externals=externals
+            )
+
+    def test_conditional_return(self, id_version):
+        @gtscript.function
+        def _test_conditional_return(arg):
+            if arg > 1:
+                tmp = 1
+            else:
+                tmp = 2
+            return tmp
+
+        def definition_func(phi: gtscript.Field[np.float64]):
+            from __externals__ import test
+
+            with computation(PARALLEL), interval(...):
+                phi = test(phi)
+
+        module = f"TestFunctionReturn_test_conditional_return_{id_version}"
+        externals = {"test": _test_conditional_return}
+
+        compile_definition(definition_func, "test_conditional_return", module, externals=externals)
+
+
 class TestCompileTimeAssertions:
     def test_nomsg(self, id_version):
         def definition(inout_field: gtscript.Field[float]):


### PR DESCRIPTION
This PR reshapes a few origins and domains in stencil calls to support the `mask` argument.
